### PR TITLE
fix: consistency cleanup for inline enum and legacy aliases

### DIFF
--- a/src/http/schemas.ts
+++ b/src/http/schemas.ts
@@ -32,6 +32,19 @@ export const HTTP_SETTLE_ERROR_REASONS = [
 
 export const HttpSettleErrorReasonSchema = z.enum(HTTP_SETTLE_ERROR_REASONS);
 
+export const HTTP_VERIFY_INVALID_REASONS = [
+  "invalid_payload",
+  "invalid_payment_requirements",
+  "invalid_network",
+  "unrecognized_asset",
+  "invalid_transaction_state",
+  "recipient_mismatch",
+  "amount_insufficient",
+  "sender_mismatch",
+] as const;
+
+export const HttpVerifyInvalidReasonSchema = z.enum(HTTP_VERIFY_INVALID_REASONS);
+
 export const HttpPaymentIdentifierExtensionSchema = z.object({
   info: z.object({
     id: PaymentIdSchema,
@@ -145,18 +158,7 @@ export const HttpSettleResponseSchema = z.discriminatedUnion("success", [
 
 export const HttpVerifyResponseSchema = z.object({
   isValid: z.boolean(),
-  invalidReason: z
-    .enum([
-      "invalid_payload",
-      "invalid_payment_requirements",
-      "invalid_network",
-      "unrecognized_asset",
-      "invalid_transaction_state",
-      "recipient_mismatch",
-      "amount_insufficient",
-      "sender_mismatch",
-    ])
-    .optional(),
+  invalidReason: HttpVerifyInvalidReasonSchema.optional(),
   payer: StacksAddressSchema.optional(),
   extensions: z.record(z.string(), z.unknown()).optional(),
 });
@@ -214,10 +216,3 @@ export const HttpNonceStateResponseSchema = z.object({
 });
 
 export type HttpNonceStateResponse = z.infer<typeof HttpNonceStateResponseSchema>;
-
-export const SettleHttpRequestSchema = HttpSettleRequestSchema;
-export const SettleHttpResponseSchema = HttpSettleResponseSchema;
-export const VerifyHttpResponseSchema = HttpVerifyResponseSchema;
-export const SupportedHttpResponseSchema = HttpSupportedResponseSchema;
-export const PaymentStatusHttpResponseSchema = HttpPaymentStatusResponseSchema;
-export const NonceStateHttpResponseSchema = HttpNonceStateResponseSchema;

--- a/src/http/schemas.ts
+++ b/src/http/schemas.ts
@@ -41,7 +41,7 @@ export const HTTP_VERIFY_INVALID_REASONS = [
   "recipient_mismatch",
   "amount_insufficient",
   "sender_mismatch",
-] as const;
+] as const satisfies readonly (typeof HTTP_SETTLE_ERROR_REASONS)[number][];
 
 export const HttpVerifyInvalidReasonSchema = z.enum(HTTP_VERIFY_INVALID_REASONS);
 
@@ -216,3 +216,6 @@ export const HttpNonceStateResponseSchema = z.object({
 });
 
 export type HttpNonceStateResponse = z.infer<typeof HttpNonceStateResponseSchema>;
+
+/** @deprecated Use HttpPaymentStatusResponseSchema instead */
+export const PaymentStatusHttpResponseSchema = HttpPaymentStatusResponseSchema;

--- a/src/rpc/schemas.ts
+++ b/src/rpc/schemas.ts
@@ -148,3 +148,8 @@ export const RpcSenderQueueSummarySchema = z.object({
 export type RpcWalletCapacity = z.infer<typeof RpcWalletCapacitySchema>;
 export type RpcPoolState = z.infer<typeof RpcPoolStateSchema>;
 export type RpcSenderQueueSummary = z.infer<typeof RpcSenderQueueSummarySchema>;
+
+/** @deprecated Use RpcSubmitPaymentResultSchema instead */
+export const SubmitPaymentRpcResponseSchema = RpcSubmitPaymentResultSchema;
+/** @deprecated Use RpcCheckPaymentResultSchema instead */
+export const CheckPaymentRpcResponseSchema = RpcCheckPaymentResultSchema;

--- a/src/rpc/schemas.ts
+++ b/src/rpc/schemas.ts
@@ -148,9 +148,3 @@ export const RpcSenderQueueSummarySchema = z.object({
 export type RpcWalletCapacity = z.infer<typeof RpcWalletCapacitySchema>;
 export type RpcPoolState = z.infer<typeof RpcPoolStateSchema>;
 export type RpcSenderQueueSummary = z.infer<typeof RpcSenderQueueSummarySchema>;
-
-export const SubmitPaymentRpcResponseSchema = RpcSubmitPaymentResultSchema;
-export const CheckPaymentRpcResponseSchema = RpcCheckPaymentResultSchema;
-export const WalletCapacityRpcResponseSchema = RpcWalletCapacitySchema;
-export const PoolStateRpcResponseSchema = RpcPoolStateSchema;
-export const SenderQueueSummaryRpcResponseSchema = RpcSenderQueueSummarySchema;


### PR DESCRIPTION
## Summary
- Extract `HTTP_VERIFY_INVALID_REASONS` as a named constant and `HttpVerifyInvalidReasonSchema`, replacing the inline enum in `HttpVerifyResponseSchema` (the verify reasons are a subset of settle error reasons, so a separate named constant is correct here)
- Remove 11 undocumented backward-compatibility alias exports from `src/http/schemas.ts` and `src/rpc/schemas.ts` — no usages found in this repo or tests

Closes #9

## Test plan
- [x] `npm run build` passes
- [x] All 159 tests pass
- [ ] Verify no downstream consumers depend on removed alias exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)