### PR TITLE
Add shared news beat lifecycle transition schemas

### DIFF
--- a/src/news/beat.ts
+++ b/src/news/beat.ts
@@ -25,6 +25,19 @@ export const BeatLifecycleMetadataSchema = BeatLifecycleFlagsSchema.extend(
   BeatTransitionMetadataSchema.shape,
 );
 
+const BEAT_LIFECYCLE_METADATA_KEYS = [
+  "lifecycle",
+  "is_fileable",
+  "is_listed_active",
+  "is_assignable_editor",
+  "archive_only",
+  "replacement_beats",
+  "transition_started_at",
+  "transition_effective_at",
+  "transition_message",
+  "transition_docs_url",
+] as const satisfies readonly (keyof z.infer<typeof BeatLifecycleMetadataSchema>)[];
+
 const BeatBaseSchema = z.object({
   slug: z.string().min(1),
   name: z.string().min(1),
@@ -38,21 +51,39 @@ const BeatBaseSchema = z.object({
 });
 
 /**
- * A named topic beat for news signals.
- * daily_approved_limit caps the number of approved signals per day (null = unlimited).
- * editor_review_rate_sats is the per-review payment rate for the beat editor (null = not configured).
- */
-export const BeatSchema = BeatBaseSchema.extend(BeatLifecycleMetadataSchema.partial().shape);
-
-/**
  * A beat record with explicit lifecycle metadata for active/grace/retired flows.
  */
 export const BeatWithLifecycleSchema = BeatBaseSchema.extend(BeatLifecycleMetadataSchema.shape);
+
+/**
+ * A named topic beat for news signals.
+ * daily_approved_limit caps the number of approved signals per day (null = unlimited).
+ * editor_review_rate_sats is the per-review payment rate for the beat editor (null = not configured).
+ *
+ * Lifecycle metadata is all-or-nothing to avoid ambiguous partial states in downstream consumers.
+ */
+export const BeatSchema = BeatBaseSchema.extend(BeatLifecycleMetadataSchema.partial().shape).superRefine(
+  (beat, ctx) => {
+    const presentKeys = BEAT_LIFECYCLE_METADATA_KEYS.filter((key) => key in beat);
+    if (presentKeys.length > 0 && presentKeys.length < BEAT_LIFECYCLE_METADATA_KEYS.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "Lifecycle metadata must be omitted entirely or provided as a complete set of lifecycle fields.",
+      });
+    }
+  },
+);
 
 export const BEAT_TRANSITION_RESPONSE_CODES = ["beat_transition_grace", "beat_retired"] as const;
 
 export const BeatTransitionResponseCodeSchema = z.enum(BEAT_TRANSITION_RESPONSE_CODES);
 
+/**
+ * Response payload guidance intentionally uses `docs_url` / `message_for_agent`
+ * while persisted beat lifecycle metadata uses `transition_docs_url` / `transition_message`.
+ * The Phase 3 cutover contract distinguishes record fields from response fields.
+ */
 export const BeatSelfHealingGuidanceSchema = z.object({
   replacement_beats: z.array(z.string().min(1)),
   transition_started_at: IsoDateTimeSchema.nullable(),
@@ -64,14 +95,9 @@ export const BeatSelfHealingGuidanceSchema = z.object({
 /**
  * Structured success metadata for filing during a grace-period beat transition.
  */
-export const BeatGracePeriodSuccessSchema = z.object({
+export const BeatGracePeriodSuccessSchema = BeatSelfHealingGuidanceSchema.extend({
   code: z.literal("beat_transition_grace"),
   beat_lifecycle: z.literal("grace"),
-  replacement_beats: BeatSelfHealingGuidanceSchema.shape.replacement_beats,
-  transition_started_at: BeatSelfHealingGuidanceSchema.shape.transition_started_at,
-  transition_effective_at: BeatSelfHealingGuidanceSchema.shape.transition_effective_at,
-  docs_url: BeatSelfHealingGuidanceSchema.shape.docs_url,
-  message_for_agent: BeatSelfHealingGuidanceSchema.shape.message_for_agent,
 });
 
 /**
@@ -84,16 +110,11 @@ export const BeatGracePeriodSuccessEnvelopeSchema = z.object({
 /**
  * Machine-readable rejection contract for retired-beat filing/join attempts.
  */
-export const BeatRetiredActionErrorSchema = z.object({
+export const BeatRetiredActionErrorSchema = BeatSelfHealingGuidanceSchema.extend({
   error: z.string().min(1),
   code: z.literal("beat_retired"),
   beat_lifecycle: z.literal("retired"),
   archive_only: z.literal(true),
-  replacement_beats: BeatSelfHealingGuidanceSchema.shape.replacement_beats,
-  transition_started_at: BeatSelfHealingGuidanceSchema.shape.transition_started_at,
-  transition_effective_at: BeatSelfHealingGuidanceSchema.shape.transition_effective_at,
-  docs_url: BeatSelfHealingGuidanceSchema.shape.docs_url,
-  message_for_agent: BeatSelfHealingGuidanceSchema.shape.message_for_agent,
 });
 
 /**

--- a/src/news/beat.ts
+++ b/src/news/beat.ts
@@ -1,20 +1,99 @@
 import { z } from "zod";
+import { IsoDateTimeSchema, UrlSchema } from "../core/primitives.js";
+
+export const BEAT_LIFECYCLE_STATES = ["active", "grace", "retired"] as const;
+
+export const BeatLifecycleStateSchema = z.enum(BEAT_LIFECYCLE_STATES);
+
+export const BeatTransitionMetadataSchema = z.object({
+  replacement_beats: z.array(z.string().min(1)),
+  transition_started_at: IsoDateTimeSchema.nullable(),
+  transition_effective_at: IsoDateTimeSchema.nullable(),
+  transition_message: z.string().min(1).nullable(),
+  transition_docs_url: UrlSchema.nullable(),
+});
+
+export const BeatLifecycleFlagsSchema = z.object({
+  lifecycle: BeatLifecycleStateSchema,
+  is_fileable: z.boolean(),
+  is_listed_active: z.boolean(),
+  is_assignable_editor: z.boolean(),
+  archive_only: z.boolean(),
+});
+
+export const BeatLifecycleMetadataSchema = BeatLifecycleFlagsSchema.extend(
+  BeatTransitionMetadataSchema.shape,
+);
+
+const BeatBaseSchema = z.object({
+  slug: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().nullable(),
+  color: z.string().nullable(),
+  created_by: z.string().min(1),
+  created_at: IsoDateTimeSchema,
+  updated_at: IsoDateTimeSchema,
+  daily_approved_limit: z.number().int().positive().nullable(),
+  editor_review_rate_sats: z.number().int().positive().nullable(),
+});
 
 /**
  * A named topic beat for news signals.
  * daily_approved_limit caps the number of approved signals per day (null = unlimited).
  * editor_review_rate_sats is the per-review payment rate for the beat editor (null = not configured).
  */
-export const BeatSchema = z.object({
-  slug: z.string().min(1),
-  name: z.string().min(1),
-  description: z.string().nullable(),
-  color: z.string().nullable(),
-  created_by: z.string().min(1),
-  created_at: z.string().datetime({ offset: true }),
-  updated_at: z.string().datetime({ offset: true }),
-  daily_approved_limit: z.number().int().positive().nullable(),
-  editor_review_rate_sats: z.number().int().positive().nullable(),
+export const BeatSchema = BeatBaseSchema.extend(BeatLifecycleMetadataSchema.partial().shape);
+
+/**
+ * A beat record with explicit lifecycle metadata for active/grace/retired flows.
+ */
+export const BeatWithLifecycleSchema = BeatBaseSchema.extend(BeatLifecycleMetadataSchema.shape);
+
+export const BEAT_TRANSITION_RESPONSE_CODES = ["beat_transition_grace", "beat_retired"] as const;
+
+export const BeatTransitionResponseCodeSchema = z.enum(BEAT_TRANSITION_RESPONSE_CODES);
+
+export const BeatSelfHealingGuidanceSchema = z.object({
+  replacement_beats: z.array(z.string().min(1)),
+  transition_started_at: IsoDateTimeSchema.nullable(),
+  transition_effective_at: IsoDateTimeSchema.nullable(),
+  docs_url: UrlSchema.nullable(),
+  message_for_agent: z.string().min(1),
+});
+
+/**
+ * Structured success metadata for filing during a grace-period beat transition.
+ */
+export const BeatGracePeriodSuccessSchema = z.object({
+  code: z.literal("beat_transition_grace"),
+  beat_lifecycle: z.literal("grace"),
+  replacement_beats: BeatSelfHealingGuidanceSchema.shape.replacement_beats,
+  transition_started_at: BeatSelfHealingGuidanceSchema.shape.transition_started_at,
+  transition_effective_at: BeatSelfHealingGuidanceSchema.shape.transition_effective_at,
+  docs_url: BeatSelfHealingGuidanceSchema.shape.docs_url,
+  message_for_agent: BeatSelfHealingGuidanceSchema.shape.message_for_agent,
+});
+
+/**
+ * Wrapper for success payloads that include beat transition guidance.
+ */
+export const BeatGracePeriodSuccessEnvelopeSchema = z.object({
+  transition: BeatGracePeriodSuccessSchema,
+});
+
+/**
+ * Machine-readable rejection contract for retired-beat filing/join attempts.
+ */
+export const BeatRetiredActionErrorSchema = z.object({
+  error: z.string().min(1),
+  code: z.literal("beat_retired"),
+  beat_lifecycle: z.literal("retired"),
+  archive_only: z.literal(true),
+  replacement_beats: BeatSelfHealingGuidanceSchema.shape.replacement_beats,
+  transition_started_at: BeatSelfHealingGuidanceSchema.shape.transition_started_at,
+  transition_effective_at: BeatSelfHealingGuidanceSchema.shape.transition_effective_at,
+  docs_url: BeatSelfHealingGuidanceSchema.shape.docs_url,
+  message_for_agent: BeatSelfHealingGuidanceSchema.shape.message_for_agent,
 });
 
 /**
@@ -37,5 +116,15 @@ export const BeatMemberSchema = z.object({
 });
 
 export type Beat = z.infer<typeof BeatSchema>;
+export type BeatWithLifecycle = z.infer<typeof BeatWithLifecycleSchema>;
+export type BeatLifecycleState = z.infer<typeof BeatLifecycleStateSchema>;
+export type BeatTransitionMetadata = z.infer<typeof BeatTransitionMetadataSchema>;
+export type BeatLifecycleFlags = z.infer<typeof BeatLifecycleFlagsSchema>;
+export type BeatLifecycleMetadata = z.infer<typeof BeatLifecycleMetadataSchema>;
+export type BeatTransitionResponseCode = z.infer<typeof BeatTransitionResponseCodeSchema>;
+export type BeatSelfHealingGuidance = z.infer<typeof BeatSelfHealingGuidanceSchema>;
+export type BeatGracePeriodSuccess = z.infer<typeof BeatGracePeriodSuccessSchema>;
+export type BeatGracePeriodSuccessEnvelope = z.infer<typeof BeatGracePeriodSuccessEnvelopeSchema>;
+export type BeatRetiredActionError = z.infer<typeof BeatRetiredActionErrorSchema>;
 export type BeatClaim = z.infer<typeof BeatClaimSchema>;
 export type BeatMember = z.infer<typeof BeatMemberSchema>;

--- a/tests/news.test.ts
+++ b/tests/news.test.ts
@@ -19,8 +19,20 @@ import {
   SourceSchema,
   BriefSchema,
   BeatSchema,
+  BeatWithLifecycleSchema,
   BeatClaimSchema,
   BeatMemberSchema,
+  BEAT_LIFECYCLE_STATES,
+  BeatLifecycleStateSchema,
+  BeatTransitionMetadataSchema,
+  BeatLifecycleFlagsSchema,
+  BeatLifecycleMetadataSchema,
+  BEAT_TRANSITION_RESPONSE_CODES,
+  BeatTransitionResponseCodeSchema,
+  BeatSelfHealingGuidanceSchema,
+  BeatGracePeriodSuccessSchema,
+  BeatGracePeriodSuccessEnvelopeSchema,
+  BeatRetiredActionErrorSchema,
 } from "../src/news/index.js";
 
 const VALID_DATETIME = "2026-04-06T12:00:00Z";
@@ -332,9 +344,36 @@ describe("news beat schema", () => {
     daily_approved_limit: null,
     editor_review_rate_sats: null,
   };
+  const validLifecycleMetadata = {
+    lifecycle: "grace" as const,
+    is_fileable: true,
+    is_listed_active: false,
+    is_assignable_editor: false,
+    archive_only: false,
+    replacement_beats: ["aibtc-network", "bitcoin-macro", "quantum"],
+    transition_started_at: VALID_DATETIME,
+    transition_effective_at: VALID_DATETIME,
+    transition_message: "This beat is retiring soon.",
+    transition_docs_url: "https://example.com/docs/aibtc-news-cutover",
+  };
 
   it("BeatSchema accepts valid beat with nullable limits", () => {
     expect(BeatSchema.safeParse(validBeat).success).toBe(true);
+  });
+
+  it("BeatSchema remains backward compatible when lifecycle metadata is omitted", () => {
+    expect(BeatSchema.safeParse(validBeat).success).toBe(true);
+  });
+
+  it("BeatSchema accepts beat with lifecycle metadata when present", () => {
+    expect(BeatSchema.safeParse({ ...validBeat, ...validLifecycleMetadata }).success).toBe(true);
+  });
+
+  it("BeatWithLifecycleSchema requires explicit lifecycle metadata", () => {
+    expect(BeatWithLifecycleSchema.safeParse(validBeat).success).toBe(false);
+    expect(BeatWithLifecycleSchema.safeParse({ ...validBeat, ...validLifecycleMetadata }).success).toBe(
+      true,
+    );
   });
 
   it("BeatSchema accepts beat with daily_approved_limit set", () => {
@@ -348,6 +387,129 @@ describe("news beat schema", () => {
   it("BeatSchema rejects non-positive daily_approved_limit", () => {
     expect(BeatSchema.safeParse({ ...validBeat, daily_approved_limit: 0 }).success).toBe(false);
     expect(BeatSchema.safeParse({ ...validBeat, daily_approved_limit: -1 }).success).toBe(false);
+  });
+
+  it("Beat lifecycle states include active, grace, retired", () => {
+    expect([...BEAT_LIFECYCLE_STATES]).toEqual(["active", "grace", "retired"]);
+    expect(BeatLifecycleStateSchema.safeParse("retired").success).toBe(true);
+    expect(BeatLifecycleStateSchema.safeParse("inactive").success).toBe(false);
+  });
+
+  it("BeatTransitionMetadataSchema accepts nullable transition timestamps and docs url", () => {
+    expect(
+      BeatTransitionMetadataSchema.safeParse({
+        replacement_beats: [],
+        transition_started_at: null,
+        transition_effective_at: null,
+        transition_message: null,
+        transition_docs_url: null,
+      }).success,
+    ).toBe(true);
+  });
+
+  it("BeatLifecycleFlagsSchema requires machine-readable lifecycle booleans", () => {
+    expect(
+      BeatLifecycleFlagsSchema.safeParse({
+        lifecycle: "active",
+        is_fileable: true,
+        is_listed_active: true,
+        is_assignable_editor: true,
+        archive_only: false,
+      }).success,
+    ).toBe(true);
+
+    expect(
+      BeatLifecycleFlagsSchema.safeParse({
+        lifecycle: "active",
+        is_fileable: true,
+        is_listed_active: true,
+        is_assignable_editor: true,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("BeatLifecycleMetadataSchema combines lifecycle flags and transition metadata", () => {
+    expect(BeatLifecycleMetadataSchema.safeParse(validLifecycleMetadata).success).toBe(true);
+  });
+
+  it("Beat transition response codes are stable", () => {
+    expect([...BEAT_TRANSITION_RESPONSE_CODES]).toEqual(["beat_transition_grace", "beat_retired"]);
+    expect(BeatTransitionResponseCodeSchema.safeParse("beat_transition_grace").success).toBe(true);
+    expect(BeatTransitionResponseCodeSchema.safeParse("unknown").success).toBe(false);
+  });
+
+  it("BeatSelfHealingGuidanceSchema accepts reusable response guidance", () => {
+    expect(
+      BeatSelfHealingGuidanceSchema.safeParse({
+        replacement_beats: ["bitcoin-macro"],
+        transition_started_at: VALID_DATETIME,
+        transition_effective_at: VALID_DATETIME,
+        docs_url: "https://example.com/docs/aibtc-news-cutover",
+        message_for_agent: "Choose an active beat and retry.",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("BeatGracePeriodSuccessSchema accepts grace-period success metadata", () => {
+    expect(
+      BeatGracePeriodSuccessSchema.safeParse({
+        code: "beat_transition_grace",
+        beat_lifecycle: "grace",
+        replacement_beats: ["bitcoin-macro"],
+        transition_started_at: VALID_DATETIME,
+        transition_effective_at: VALID_DATETIME,
+        docs_url: "https://example.com/docs/aibtc-news-cutover",
+        message_for_agent: "This beat is retiring soon. Refile future work under an active beat.",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("BeatGracePeriodSuccessEnvelopeSchema accepts the nested transition block contract", () => {
+    expect(
+      BeatGracePeriodSuccessEnvelopeSchema.safeParse({
+        transition: {
+          code: "beat_transition_grace",
+          beat_lifecycle: "grace",
+          replacement_beats: ["bitcoin-macro"],
+          transition_started_at: VALID_DATETIME,
+          transition_effective_at: VALID_DATETIME,
+          docs_url: "https://example.com/docs/aibtc-news-cutover",
+          message_for_agent: "This beat is retiring soon. Refile future work under an active beat.",
+        },
+      }).success,
+    ).toBe(true);
+  });
+
+  it("BeatRetiredActionErrorSchema accepts machine-readable retired-beat errors", () => {
+    expect(
+      BeatRetiredActionErrorSchema.safeParse({
+        error: 'Beat "legacy-slug" is retired and no longer accepts new filings',
+        code: "beat_retired",
+        beat_lifecycle: "retired",
+        archive_only: true,
+        replacement_beats: ["quantum"],
+        transition_started_at: VALID_DATETIME,
+        transition_effective_at: VALID_DATETIME,
+        docs_url: "https://example.com/docs/aibtc-news-cutover",
+        message_for_agent: "This beat is archive-only. Choose an active beat and retry.",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("BeatRetiredActionErrorSchema rejects archive_only=false", () => {
+    expect(
+      BeatRetiredActionErrorSchema.safeParse({
+        error: 'Beat "legacy-slug" is retired and no longer accepts new filings',
+        code: "beat_retired",
+        beat_lifecycle: "retired",
+        archive_only: false,
+        replacement_beats: ["quantum"],
+        transition_started_at: VALID_DATETIME,
+        transition_effective_at: VALID_DATETIME,
+        docs_url: "https://example.com/docs/aibtc-news-cutover",
+        message_for_agent: "This beat is archive-only. Choose an active beat and retry.",
+      }).success,
+    ).toBe(false);
   });
 
   it("BeatClaimSchema accepts valid claim", () => {

--- a/tests/news.test.ts
+++ b/tests/news.test.ts
@@ -361,8 +361,20 @@ describe("news beat schema", () => {
     expect(BeatSchema.safeParse(validBeat).success).toBe(true);
   });
 
-  it("BeatSchema remains backward compatible when lifecycle metadata is omitted", () => {
-    expect(BeatSchema.safeParse(validBeat).success).toBe(true);
+  it("BeatSchema rejects partial lifecycle metadata to avoid ambiguous states", () => {
+    expect(
+      BeatSchema.safeParse({
+        ...validBeat,
+        lifecycle: validLifecycleMetadata.lifecycle,
+        is_fileable: validLifecycleMetadata.is_fileable,
+      }).success,
+    ).toBe(false);
+    expect(
+      BeatSchema.safeParse({
+        ...validBeat,
+        transition_started_at: validLifecycleMetadata.transition_started_at,
+      }).success,
+    ).toBe(false);
   });
 
   it("BeatSchema accepts beat with lifecycle metadata when present", () => {


### PR DESCRIPTION
## Summary
- add reusable news-domain beat lifecycle schemas for `active | grace | retired`
- add shared transition metadata and self-healing response schemas for grace-period success and retired-beat errors
- keep `BeatSchema` backward-compatible while exposing stricter lifecycle-aware variants

## Testing
- `npm run typecheck`
- `npm run build`
- `npm test -- --run tests/news.test.ts`
- `npm test`