### PR TITLE
feat(news): document news schema exports and lifecycle contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ npm install @aibtc/tx-schemas zod
 - `@aibtc/tx-schemas/core` exports canonical payment enums, terminal reasons, and shared primitives
 - `@aibtc/tx-schemas/rpc` exports internal relay service-binding schemas
 - `@aibtc/tx-schemas/http` exports external x402 facilitator and polling schemas
+- `@aibtc/tx-schemas/news` exports shared editorial/newsroom schemas, including beat lifecycle transition contracts
 
 ## Usage
 
@@ -60,6 +61,7 @@ const settleRequest = HttpSettleRequestSchema.parse({
 - `@aibtc/tx-schemas/core/terminal-reasons`
 - `@aibtc/tx-schemas/rpc`
 - `@aibtc/tx-schemas/http`
+- `@aibtc/tx-schemas/news`
 
 ## Schema Rules
 

--- a/docs/package-schemas.md
+++ b/docs/package-schemas.md
@@ -11,6 +11,7 @@
 - `@aibtc/tx-schemas/terminal-reasons` exports terminal-reason enums and mappings.
 - `@aibtc/tx-schemas/rpc` exports internal first-party RPC schemas.
 - `@aibtc/tx-schemas/http` exports external HTTP schemas.
+- `@aibtc/tx-schemas/news` exports shared newsroom/editorial schemas, including beat lifecycle transition primitives.
 
 ## Naming Rules
 
@@ -26,6 +27,7 @@ This keeps domain semantics stable even when transports choose different field n
 - `src/core` owns canonical semantics only.
 - `src/rpc` owns first-party service-binding request and response shapes.
 - `src/http` owns x402/HTTP request and response shapes plus polling/error envelopes.
+- `src/news` owns shared editorial/newsroom domain schemas used across news services.
 
 RPC and HTTP may differ in field names, envelopes, and transport-specific error codes.
 


### PR DESCRIPTION
## Why
PR #16 merged with a non-conventional commit title on `main`, so Release Please did not open a release PR and npm publish could not run.

This follow-up PR lands a minimal conventional `feat(news): ...` change so the squash merge commit on `main` is release-please-compatible and can trigger the next patch/minor release flow.

## Changes
- document the `@aibtc/tx-schemas/news` subpath in the README
- document `src/news` / newsroom schema ownership in package docs

## Merge Instructions
- squash merge this PR
- keep the squash title exactly as: `feat(news): document news schema exports and lifecycle contract`

## Validation
- `npm run build`
- `npm test`