### PR TITLE
Lock boring payment state machine contract for relay polling and recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,13 @@ const settleRequest = HttpSettleRequestSchema.parse({
 - The default protected-resource delivery invariant is `deliver-only-on-confirmed`.
 - Any product that delivers on in-flight states should document that as an application exception, not a canonical package rule.
 - `paymentId` is relay-owned and duplicate submission should reuse the same `paymentId` until terminal resolution.
+- `payment-identifier` is client-supplied idempotency input only. It must not be treated as canonical public `paymentId`.
 - Accepted duplicate submit responses should return the current caller-facing in-flight status for that `paymentId`: `queued`, `broadcasting`, or `mempool` as applicable.
 - `queued_with_warning` remains an RPC-only temporary compatibility shim for warning-aware callers during migration.
 - Polling contracts may surface `checkStatusUrl` as an additive convenience field, and internal/external polling should treat it as another way to reach the same `paymentId` lifecycle.
+- If a downstream consumer has neither relay `paymentId` nor canonical `checkStatusUrl`, it must fail closed instead of inventing a polling identity.
 - Terminal polling responses should carry a normalized `terminalReason` when one is known, even if transports also emit local error codes.
+- Machine-readable contract exports for downstream repos include `CanonicalDomainBoundary`, `CANONICAL_POLLING_IDENTITY_FIELDS`, `RELAY_LIFECYCLE_BRIDGE`, and `TERMINAL_REASON_CATEGORY_HANDLING`.
 
 More detail lives in [docs/package-schemas.md](docs/package-schemas.md),
 [docs/boring-state-machine-contract.md](docs/boring-state-machine-contract.md),

--- a/docs/boring-state-machine-contract.md
+++ b/docs/boring-state-machine-contract.md
@@ -34,6 +34,8 @@ Notes:
 
 The relay implementation has to keep one canonical `paymentId` attached across this bridge:
 
+The row order below is normative. It is the frozen transition sequence for the relay lifecycle bridge, not a display-only convention.
+
 | Relay step | Caller-facing state projection | Contract |
 | --- | --- | --- |
 | sender-hand accepted | `queued` | relay accepted sender-hand ownership for this `paymentId` |

--- a/docs/boring-state-machine-contract.md
+++ b/docs/boring-state-machine-contract.md
@@ -108,7 +108,8 @@ Relay-owned responsibilities:
 | Seen in mempool | `mempool` | | do not deliver by default unless route exception is documented | poll |
 | Confirmed on-chain | `confirmed` | | deliver | success |
 | Sender nonce stale | `failed` | `sender_nonce_stale` | do not deliver | rebuild transaction |
-| Sender nonce gap | `failed` | `sender_nonce_gap` | do not deliver | rebuild or submit missing nonce |
+| Sender nonce gap before canonical acceptance | `failed` | `sender_nonce_gap` | do not deliver | rebuild or submit missing nonce |
+| Accepted payment blocked on sender nonce gap | `queued` | | do not deliver | keep polling the same `paymentId`; use hold or wedge diagnostics to decide whether to submit missing nonces or escalate |
 | Invalid transaction | `failed` | `invalid_transaction` | do not deliver | stop |
 | Sponsor/relay internal failure | `failed` | `queue_unavailable`, `sponsor_failure`, or `internal_error` | do not deliver | bounded retry only if adapter marks retryable |
 | Broadcast failure | `failed` | `broadcast_failure` or `chain_abort` | do not deliver | treat as failed; rebuild only if caller owns sender recovery |

--- a/docs/boring-state-machine-contract.md
+++ b/docs/boring-state-machine-contract.md
@@ -1,6 +1,6 @@
 # Boring State Machine Contract: Phase 1 Packet
 
-This document is the phase 1 coordination packet for the `2026-04-01-boring-tx-state-machine` quest.
+This document is the phase 1 coordination packet for the `2026-04-09-boring-payment-state-machine` quest.
 
 It freezes the canonical contract that downstream repos should consume before relay and service migrations continue.
 
@@ -23,9 +23,25 @@ Notes:
 ## Identity and Duplicate Handling
 
 - `paymentId` is relay-owned.
+- `payment-identifier` is a client-supplied idempotency input only. It is not a public polling identity and must never be surfaced or reconstructed as canonical `paymentId`.
 - Duplicate submission of the same already-known payment artifact should reuse the same `paymentId` until that payment reaches a terminal state.
 - Accepted duplicate submit responses should return the current caller-facing in-flight status for that reused `paymentId`: `queued`, `broadcasting`, or `mempool` as applicable.
 - Internal and external polling should both treat `paymentId` as the stable handle for in-flight and terminal lookup.
+- `checkStatusUrl` is an additive canonical poll hint for the same relay-owned lifecycle.
+- If a consumer has neither relay `paymentId` nor canonical `checkStatusUrl`, it must fail closed rather than inventing a polling identity.
+
+## Required Relay Lifecycle Bridge
+
+The relay implementation has to keep one canonical `paymentId` attached across this bridge:
+
+| Relay step | Caller-facing state projection | Contract |
+| --- | --- | --- |
+| sender-hand accepted | `queued` | relay accepted sender-hand ownership for this `paymentId` |
+| queued for sponsor dispatch | `queued` | the same `paymentId` is now queued under sponsor dispatch ownership |
+| sponsor broadcasted | `broadcasting`, then `mempool` when observed | chain visibility changes, but the canonical identity does not |
+| confirmed | `confirmed` | canonical delivery success |
+| replaced | `replaced` | old `paymentId` is terminal because another tx won the nonce |
+| terminal failed | `failed` | old `paymentId` is terminal failed with a normalized `terminalReason` |
 
 ## Terminal Outcome Contract
 
@@ -53,6 +69,17 @@ Relay-owned responsibilities:
 - sponsor ordering and sponsor nonce recovery
 - in-flight payment transitions
 - terminal settlement truth
+
+## Terminal Reason Handling Guidance
+
+| Terminal reason category | Recovery owner | Expected client action |
+| --- | --- | --- |
+| `validation` | sender | stop and fix the request or signed transaction |
+| `sender` | sender | rebuild and re-sign a new payment |
+| `relay` | relay | use bounded retry on the same `paymentId` only when the adapter marks it retryable |
+| `settlement` | relay | treat broadcast or settlement failures as relay-owned recovery on the same `paymentId` unless sender repair is explicitly required |
+| `replacement` | caller | stop polling the old `paymentId`; decide the next action explicitly |
+| `identity` | caller | the old identity is gone; restart the higher-level flow with a new payment and never invent a replacement `paymentId` |
 
 ## Compatibility Notes
 
@@ -84,4 +111,4 @@ Relay-owned responsibilities:
 | Sponsor/relay internal failure | `failed` | `queue_unavailable`, `sponsor_failure`, or `internal_error` | do not deliver | bounded retry only if adapter marks retryable |
 | Broadcast failure | `failed` | `broadcast_failure` or `chain_abort` | do not deliver | treat as failed; rebuild only if caller owns sender recovery |
 | Nonce replacement | `replaced` | `nonce_replacement` or `superseded` | do not deliver | stop polling old `paymentId`; decide next client action explicitly |
-| Missing or expired identity | `not_found` | `expired` or `unknown_payment_identity` | do not deliver | stop or restart from a new payment flow |
+| Missing or expired identity | `not_found` | `expired` or `unknown_payment_identity` | do not deliver | old identity is gone; restart the higher-level flow with a new payment and never retry the old `paymentId` |

--- a/src/core/enums.ts
+++ b/src/core/enums.ts
@@ -82,6 +82,8 @@ export const CANONICAL_POLLING_IDENTITY_FIELDS = [
   "checkStatusUrl",
 ] as const;
 
+// Array order is part of the contract: downstream consumers may rely on this
+// sequence as the required relay lifecycle bridge from acceptance to terminality.
 export const RELAY_LIFECYCLE_BRIDGE = [
   {
     step: "sender_hand_accepted",
@@ -145,6 +147,7 @@ export const CanonicalDomainBoundary = {
     canonicalFields: CANONICAL_POLLING_IDENTITY_FIELDS,
     missingCanonicalIdentityPolicy: "downstream-must-not-invent-paymentId-or-checkStatusUrl",
   },
+  relayLifecycleBridgeOrdering: "ordered-transition-sequence",
   relayLifecycleBridge: RELAY_LIFECYCLE_BRIDGE,
   recoveryBoundaries: {
     senderOwned: [

--- a/src/core/enums.ts
+++ b/src/core/enums.ts
@@ -77,6 +77,44 @@ export const paymentStateCategoryByState = PAYMENT_STATE_TO_CATEGORY;
 export const PaymentStateDefaultDeliveryByState = PAYMENT_STATE_DEFAULT_DELIVERY;
 export const paymentStateDefaultDeliveryByState = PAYMENT_STATE_DEFAULT_DELIVERY;
 
+export const CANONICAL_POLLING_IDENTITY_FIELDS = [
+  "paymentId",
+  "checkStatusUrl",
+] as const;
+
+export const RELAY_LIFECYCLE_BRIDGE = [
+  {
+    step: "sender_hand_accepted",
+    callerFacingStates: ["queued"] as const,
+    contract: "relay accepted sender-hand ownership for this paymentId",
+  },
+  {
+    step: "queued_for_sponsor_dispatch",
+    callerFacingStates: ["queued"] as const,
+    contract: "relay queued the same paymentId for sponsor dispatch",
+  },
+  {
+    step: "sponsor_broadcasted",
+    callerFacingStates: ["broadcasting", "mempool"] as const,
+    contract: "relay broadcasted the same paymentId and may expose chain visibility",
+  },
+  {
+    step: "confirmed",
+    callerFacingStates: ["confirmed"] as const,
+    contract: "relay observed canonical confirmed settlement for the same paymentId",
+  },
+  {
+    step: "replaced",
+    callerFacingStates: ["replaced"] as const,
+    contract: "relay marked the old paymentId terminal because another tx won the nonce",
+  },
+  {
+    step: "terminal_failed",
+    callerFacingStates: ["failed"] as const,
+    contract: "relay marked the paymentId terminal failed with a normalized terminalReason",
+  },
+] as const;
+
 export const PAYMENT_STATE_TRANSITIONS = {
   requires_payment: [] as const,
   queued: ["queued", "broadcasting", "failed"] as const,
@@ -99,8 +137,15 @@ export const CanonicalDomainBoundary = {
   paymentIdentity: {
     owner: "relay",
     field: "paymentId",
+    idempotencyInputField: "payment-identifier",
+    idempotencyInputRole: "idempotency-input-only",
     duplicateSubmissionPolicy: "same-submission-reuses-paymentId-until-terminal-outcome",
   },
+  pollingIdentity: {
+    canonicalFields: CANONICAL_POLLING_IDENTITY_FIELDS,
+    missingCanonicalIdentityPolicy: "downstream-must-not-invent-paymentId-or-checkStatusUrl",
+  },
+  relayLifecycleBridge: RELAY_LIFECYCLE_BRIDGE,
   recoveryBoundaries: {
     senderOwned: [
       "sender nonce correctness",

--- a/src/core/terminal-reasons.ts
+++ b/src/core/terminal-reasons.ts
@@ -97,6 +97,46 @@ export const TERMINAL_REASON_TO_CATEGORY = {
 
 export const paymentTerminalReasonCategoryByReason = TERMINAL_REASON_TO_CATEGORY;
 
+export const TERMINAL_REASON_CATEGORY_HANDLING = {
+  validation: {
+    recoveryOwner: "sender",
+    clientAction: "stop-and-fix-input",
+    guidance: "Fix the request or signed transaction before retrying.",
+  },
+  sender: {
+    recoveryOwner: "sender",
+    clientAction: "rebuild-signed-payment",
+    guidance: "Build and sign a new payment after correcting sender nonce state.",
+  },
+  relay: {
+    recoveryOwner: "relay",
+    clientAction: "bounded-retry-same-payment",
+    guidance: "Retry only with bounded relay-owned recovery against the same paymentId.",
+  },
+  settlement: {
+    recoveryOwner: "relay",
+    clientAction: "bounded-retry-same-payment",
+    guidance: "Treat broadcast and settlement failures as relay-owned recovery on the same paymentId unless sender repair is explicitly required.",
+  },
+  replacement: {
+    recoveryOwner: "caller",
+    clientAction: "stop-polling-old-paymentId",
+    guidance: "The old paymentId is terminal; stop polling it and decide the next action explicitly.",
+  },
+  identity: {
+    recoveryOwner: "caller",
+    clientAction: "restart-higher-level-flow-with-new-payment-identity",
+    guidance: "The old identity is gone; restart the higher-level flow and never synthesize a replacement paymentId.",
+  },
+} as const satisfies Record<
+  (typeof TERMINAL_REASON_CATEGORIES)[number],
+  {
+    recoveryOwner: string;
+    clientAction: string;
+    guidance: string;
+  }
+>;
+
 export const TerminalReasonDetailSchema = z.object({
   reason: TerminalReasonSchema,
   category: TerminalReasonCategorySchema,

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -79,6 +79,9 @@ describe("core payment semantics", () => {
   });
 
   it("freezes the required relay lifecycle bridge ordering", () => {
+    expect(CanonicalDomainBoundary.relayLifecycleBridgeOrdering).toBe(
+      "ordered-transition-sequence",
+    );
     expect(RELAY_LIFECYCLE_BRIDGE.map((step) => step.step)).toEqual([
       "sender_hand_accepted",
       "queued_for_sponsor_dispatch",

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
+  CANONICAL_POLLING_IDENTITY_FIELDS,
   CanonicalDomainBoundary,
   PaymentIdSchema,
   PaymentStateSchema,
   PaymentStateCategoryByState,
   PaymentStatusSchema,
   ProtectedResourceDeliverableStateSchema,
+  RELAY_LIFECYCLE_BRIDGE,
+  TERMINAL_REASON_CATEGORY_HANDLING,
   TerminalReasonSchema,
   TERMINAL_REASON_TO_STATE,
 } from "../src/index.js";
@@ -57,11 +60,49 @@ describe("core payment semantics", () => {
   it("documents relay-owned payment identity and recovery boundaries", () => {
     expect(CanonicalDomainBoundary.paymentIdentity.owner).toBe("relay");
     expect(CanonicalDomainBoundary.paymentIdentity.field).toBe("paymentId");
+    expect(CanonicalDomainBoundary.paymentIdentity.idempotencyInputField).toBe(
+      "payment-identifier",
+    );
+    expect(CanonicalDomainBoundary.paymentIdentity.idempotencyInputRole).toBe(
+      "idempotency-input-only",
+    );
+    expect(CANONICAL_POLLING_IDENTITY_FIELDS).toEqual(["paymentId", "checkStatusUrl"]);
+    expect(CanonicalDomainBoundary.pollingIdentity.missingCanonicalIdentityPolicy).toBe(
+      "downstream-must-not-invent-paymentId-or-checkStatusUrl",
+    );
     expect(CanonicalDomainBoundary.recoveryBoundaries.senderOwned).toContain(
       "transaction rebuild after sender nonce stale/gap",
     );
     expect(CanonicalDomainBoundary.recoveryBoundaries.relayOwned).toContain(
       "payment identity lifecycle",
+    );
+  });
+
+  it("freezes the required relay lifecycle bridge ordering", () => {
+    expect(RELAY_LIFECYCLE_BRIDGE.map((step) => step.step)).toEqual([
+      "sender_hand_accepted",
+      "queued_for_sponsor_dispatch",
+      "sponsor_broadcasted",
+      "confirmed",
+      "replaced",
+      "terminal_failed",
+    ]);
+    expect(RELAY_LIFECYCLE_BRIDGE[0]?.callerFacingStates).toEqual(["queued"]);
+    expect(RELAY_LIFECYCLE_BRIDGE[2]?.callerFacingStates).toEqual([
+      "broadcasting",
+      "mempool",
+    ]);
+  });
+
+  it("documents client handling guidance by terminal reason category", () => {
+    expect(TERMINAL_REASON_CATEGORY_HANDLING.sender.clientAction).toBe(
+      "rebuild-signed-payment",
+    );
+    expect(TERMINAL_REASON_CATEGORY_HANDLING.relay.clientAction).toBe(
+      "bounded-retry-same-payment",
+    );
+    expect(TERMINAL_REASON_CATEGORY_HANDLING.identity.clientAction).toBe(
+      "restart-higher-level-flow-with-new-payment-identity",
     );
   });
 });

--- a/tests/parity.test.ts
+++ b/tests/parity.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
+  CANONICAL_POLLING_IDENTITY_FIELDS,
   HttpPaymentStatusResponseSchema,
   PAYMENT_STATE_DEFAULT_DELIVERY,
   PAYMENT_STATE_TO_CATEGORY,
   RpcCheckPaymentResultSchema,
+  TERMINAL_REASON_CATEGORY_HANDLING,
+  TERMINAL_REASON_TO_STATE,
 } from "../src/index.js";
 
 describe("rpc/http semantic parity", () => {
@@ -48,5 +51,28 @@ describe("rpc/http semantic parity", () => {
     expect(PAYMENT_STATE_DEFAULT_DELIVERY[rpc.status]).toBe(false);
     expect(PAYMENT_STATE_DEFAULT_DELIVERY[http.status]).toBe(false);
     expect(rpc.terminalReason).toBe(http.terminalReason);
+  });
+
+  it("keeps canonical not_found identity-gone semantics aligned across rpc and http", () => {
+    const rpc = RpcCheckPaymentResultSchema.parse({
+      paymentId: "pay_1234567890abcdef",
+      status: "not_found",
+      terminalReason: "unknown_payment_identity",
+      error: "Payment identity is gone",
+    });
+
+    const http = HttpPaymentStatusResponseSchema.parse({
+      paymentId: "pay_1234567890abcdef",
+      status: "not_found",
+      terminalReason: "unknown_payment_identity",
+      error: "Payment identity is gone",
+    });
+
+    expect(TERMINAL_REASON_TO_STATE[rpc.terminalReason!]).toBe("not_found");
+    expect(TERMINAL_REASON_TO_STATE[http.terminalReason!]).toBe("not_found");
+    expect(TERMINAL_REASON_CATEGORY_HANDLING.identity.clientAction).toBe(
+      "restart-higher-level-flow-with-new-payment-identity",
+    );
+    expect(CANONICAL_POLLING_IDENTITY_FIELDS).toEqual(["paymentId", "checkStatusUrl"]);
   });
 });

--- a/tests/parity.test.ts
+++ b/tests/parity.test.ts
@@ -75,4 +75,26 @@ describe("rpc/http semantic parity", () => {
     );
     expect(CANONICAL_POLLING_IDENTITY_FIELDS).toEqual(["paymentId", "checkStatusUrl"]);
   });
+
+  it("keeps expired not_found semantics aligned across rpc and http", () => {
+    const rpc = RpcCheckPaymentResultSchema.parse({
+      paymentId: "pay_1234567890abcdef",
+      status: "not_found",
+      terminalReason: "expired",
+      error: "Payment expired",
+    });
+
+    const http = HttpPaymentStatusResponseSchema.parse({
+      paymentId: "pay_1234567890abcdef",
+      status: "not_found",
+      terminalReason: "expired",
+      error: "Payment expired",
+    });
+
+    expect(TERMINAL_REASON_TO_STATE[rpc.terminalReason!]).toBe("not_found");
+    expect(TERMINAL_REASON_TO_STATE[http.terminalReason!]).toBe("not_found");
+    expect(TERMINAL_REASON_CATEGORY_HANDLING.identity.clientAction).toBe(
+      "restart-higher-level-flow-with-new-payment-identity",
+    );
+  });
 });


### PR DESCRIPTION
Freeze the Phase 1 boring payment state-machine contract in `tx-schemas`.

This adds machine-readable exports for canonical polling identity and the required relay lifecycle bridge, makes `payment-identifier` explicitly idempotency-only, documents confirmed as the only default deliverable state, and defines terminal-reason handling guidance by category. Docs and parity tests are updated to pin `not_found` as "old identity is gone" and keep downstream repos aligned to exported constants rather than copied prose.
